### PR TITLE
Remove unnecessary async-await

### DIFF
--- a/src/todo/test/integration/todo.service.int-spec.ts
+++ b/src/todo/test/integration/todo.service.int-spec.ts
@@ -41,8 +41,8 @@ describe('TodoService Int', () => {
       expect(todo.status).toBe(TodoStatus.OPEN);
     });
 
-    it('should throw on duplicate title', async () => {
-      await todoService
+    it('should throw on duplicate title', () => {
+      todoService
         .createTodo(userId, dto)
         .then((todo) => expect(todo).toBeUndefined())
         .catch((error) => expect(error.status).toBe(403));


### PR DESCRIPTION
If I understand correctly, the `.then(` and `.catch(` execute on our promise, and there is nothing to `await`. GIven this is tutorial code, I find the change useful especially for beginners, since they might struggle with asynchronous syntax anyway.